### PR TITLE
Add support to provide custom NCBI taxonomy file to the protein command

### DIFF
--- a/data/conterminatorprotein.sh
+++ b/data/conterminatorprotein.sh
@@ -29,9 +29,15 @@ if notExists "$TMP_PATH/sequencedb"; then
 fi
 
 if notExists "$TMP_PATH/sequencedb_mapping"; then
+if [ "$DOWNLOAD_NCBITAXDUMP" -eq "0" ]; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" createtaxdb "$TMP_PATH/sequencedb" "${TMP_PATH}/createtaxdb" --tax-mapping-file "${TAXMAPPINGFILE}" --ncbi-tax-dump "${NCBITAXINFO}" ${ONLYVERBOSITY} \
+        || fail "createtaxdb step died"
+else
     # shellcheck disable=SC2086
     "$MMSEQS" createtaxdb "$TMP_PATH/sequencedb" "${TMP_PATH}/createtaxdb" --tax-mapping-file "${TAXMAPPINGFILE}" ${ONLYVERBOSITY} \
         || fail "createtaxdb step died"
+fi
 fi
 
 if notExists "$TMP_PATH/clu.dbtype"; then

--- a/src/workflow/Conterminatorprotein.cpp
+++ b/src/workflow/Conterminatorprotein.cpp
@@ -29,6 +29,7 @@ int conterminatorprotein(int argc, const char **argv, const Command &command) {
     for(size_t i = 0; i < par.conterminatorprotein.size(); i++){
         par.conterminatorprotein[i]->category |= MMseqsParameter::COMMAND_EXPERT;
     }
+    par.PARAM_NCBI_TAX_DUMP.category = MMseqsParameter::COMMAND_MISC;
     par.PARAM_TAXON_LIST.category = MMseqsParameter::COMMAND_MISC;
     par.PARAM_BLACKLIST.category = MMseqsParameter::COMMAND_MISC;
     par.PARAM_KMER_PER_SEQ.category = MMseqsParameter::COMMAND_PREFILTER;
@@ -51,6 +52,14 @@ int conterminatorprotein(int argc, const char **argv, const Command &command) {
 
     par.filenames.pop_back();
     par.filenames.push_back(tmpDir);
+
+    if( par.PARAM_NCBI_TAX_DUMP.wasSet == false){
+        cmd.addVariable("DOWNLOAD_NCBITAXDUMP", "1");
+    }else{
+        cmd.addVariable("DOWNLOAD_NCBITAXDUMP", "0");
+        cmd.addVariable("NCBITAXINFO", par.ncbiTaxDump.c_str());
+    }
+
     cmd.addVariable("CREATEDB_PAR", par.createParameterString(par.createdb).c_str());
     cmd.addVariable("TAXMAPPINGFILE", par.db2.c_str());
     cmd.addVariable("REMOVE_TMP", par.removeTmpFiles ? "TRUE" : NULL);


### PR DESCRIPTION
The last commit added the option to provide a custom taxonomy only to the `dna` pipeline, so the `protein` command downloaded the taxonomy from NCBI even if a custom taxdump was provided.